### PR TITLE
Leverage Spring Boot reactive starter for server setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,18 +26,20 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.springframework.boot.experimental</groupId>
+			<artifactId>spring-boot-starter-web-reactive</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-tomcat</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-web-reactive</artifactId>
-		</dependency>
 
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-buffer</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>io.projectreactor.ipc</groupId>
 			<artifactId>reactor-netty</artifactId>
@@ -50,11 +52,6 @@
 		<dependency>
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
 		</dependency>
 
 		<dependency>
@@ -83,12 +80,12 @@
 			<dependency>
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-commons</artifactId>
-				<version>2.0.0.DATACMNS-836-SNAPSHOT</version>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>
 				<artifactId>spring-data-mongodb</artifactId>
-				<version>2.0.0.DATAMONGO-1444-SNAPSHOT</version>
+				<version>2.0.0.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.mongodb</groupId>

--- a/src/main/java/com/example/functional/WebFunctionPlaygroundApplication.java
+++ b/src/main/java/com/example/functional/WebFunctionPlaygroundApplication.java
@@ -5,23 +5,24 @@ import com.example.functional.domain.User;
 import com.example.functional.domain.UserRepository;
 import com.example.functional.web.UserHandler;
 import reactor.core.publisher.Mono;
-import reactor.ipc.netty.http.HttpServer;
 
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.reactiveweb.ReactiveWebAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.http.server.reactive.ReactorHttpHandlerAdapter;
-import org.springframework.web.reactive.function.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunction;
 
-import static org.springframework.web.reactive.function.RequestPredicates.*;
-import static org.springframework.web.reactive.function.RouterFunctions.*;
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.POST;
+import static org.springframework.web.reactive.function.server.RouterFunctions.route;
+import static org.springframework.web.reactive.function.server.RouterFunctions.toHttpHandler;
 
 @SpringBootApplication(
-		exclude = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+		exclude = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class, ReactiveWebAutoConfiguration.class})
 public class WebFunctionPlaygroundApplication {
 
 	public static void main(String[] args) {
@@ -44,11 +45,18 @@ public class WebFunctionPlaygroundApplication {
 	}
 
 	@Bean
+	HttpHandler httpHandler(RouterFunction<?> router) {
+		return toHttpHandler(router);
+	}
+
+	/*
+	@Bean
 	HttpServer nettyServer(RouterFunction<?> router) {
 		HttpHandler handler = toHttpHandler(router);
 		HttpServer httpServer = HttpServer.create(7080);
 		httpServer.start(new ReactorHttpHandlerAdapter(handler));
 		return httpServer;
 	}
+	*/
 
 }

--- a/src/main/java/com/example/functional/web/UserHandler.java
+++ b/src/main/java/com/example/functional/web/UserHandler.java
@@ -7,8 +7,8 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.ServerRequest;
-import org.springframework.web.reactive.function.ServerResponse;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
 
 @Component
 public class UserHandler {
@@ -19,18 +19,18 @@ public class UserHandler {
 		this.repository = repository;
 	}
 
-	public ServerResponse<Publisher<User>> listPeople(ServerRequest request) {
+	public Mono<ServerResponse> listPeople(ServerRequest request) {
 		Flux<User> people = this.repository.findAll();
 		return ServerResponse.ok().body(people, User.class);
 	}
 
-	public ServerResponse<Publisher<User>> getUser(ServerRequest request) {
+	public Mono<ServerResponse> getUser(ServerRequest request) {
 		String personId = request.pathVariable("id");
 		Mono<User> person = this.repository.findOne(personId);
 		return ServerResponse.ok().body(person, User.class);
 	}
 
-	public ServerResponse<Mono<Void>> createUser(ServerRequest request) {
+	public Mono<ServerResponse> createUser(ServerRequest request) {
 		Mono<User> user = request.bodyToMono(User.class);
 		return ServerResponse.ok().build(this.repository.save(user).then());
 	}


### PR DESCRIPTION
@sdeleuze I believe you could do the same and avoid setting up the server yourself.
I can add a new condition on the existing reactive web auto-configuration so that you woudln't have to ignore it - maybe trigger the annotation variant only if no routerfunction/httpHandler is already provided?